### PR TITLE
Add project documentation and site plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# Bowling-Green
+# Bowling Green Campaign Site
+
+This repository contains planning documents and future source code for a fully static, bilingual campaign website built with GitHub Pages and Jekyll. The site is designed for a local campaign in Trinidad, Colorado and prioritizes accessibility, mobile performance, and clear language in both English and Spanish.
+
+## Overview
+
+The project aims to help voters quickly understand the candidate's platform, RSVP for events, volunteer, donate, and find voter information. All critical pages will have Spanish mirrors and a persistent language switch.
+
+### Top-Level Navigation
+
+Home | Issues | Events | Volunteer | Voter Info | Endorsements | Newsroom | Contact | Donate | Español
+
+### Tech Stack
+
+* **Host:** GitHub Pages using Jekyll
+* **Languages:** HTML, CSS, JavaScript, Markdown, and YAML data files
+* **Integrations:** Google Forms & Calendar, external donation processor, Plausible/GoatCounter analytics
+* **Accessibility:** WCAG 2.2 AA, keyboard navigation, high-contrast and large-text toggles
+
+## Repository Structure
+
+```
+/config.yml
+/_layouts/
+/_includes/
+/_data/
+/assets/css/
+/assets/js/
+/index.md
+/issues/
+/events/
+/volunteer/
+/voter-info/
+/endorsements/
+/newsroom/
+/contact/
+/donate/
+/es/...
+/docs/
+```
+
+The `/docs` directory contains detailed planning materials, phase backlogs, and content checklists.
+
+## Getting Started
+
+1. Install Ruby and Bundler.
+2. Run `bundle install` to install Jekyll and dependencies.
+3. Serve locally with `bundle exec jekyll serve`.
+4. Edit Markdown content or data files, then commit changes via pull request.
+
+## Documentation
+
+Additional documentation is available in the `docs/` folder:
+
+* `PROJECT_PLAN.md` – complete site plan, requirements, and templates
+* `WORK_ORDERS.md` – implementation tasks for developers/agents
+* `COPY_ASSET_CHECKLIST.md` – list of required text and media assets
+* `SPANISH_GLOSSARY.md` – consistent translations for navigation and content
+
+## Contributing
+
+* Maintain English and Spanish parity for all user-facing pages.
+* Ensure all pages meet accessibility and performance goals.
+* Use plain, concise language suitable for seniors and bilingual audiences.
+* Commit changes through pull requests; include relevant documentation updates.
+
+## License
+
+A license has not yet been selected for this project.
+

--- a/docs/COPY_ASSET_CHECKLIST.md
+++ b/docs/COPY_ASSET_CHECKLIST.md
@@ -1,0 +1,34 @@
+# Copy and Asset Checklist
+
+Provide these materials to the development team so the site can be populated with real content.
+
+## Copy
+
+* Short and long candidate bio (EN & ES)
+* Issue summaries for 5–7 topics (EN → translated to ES)
+* Voter information details and key dates
+* Donate page language including disclaimers and suggested amounts
+* Response-time promise and privacy note for contact forms
+* Footer text: "Paid for by [Committee Name]. Treasurer: [Name]."
+
+## Forms & Links
+
+* Google Forms links for RSVP, Volunteer, Contact, Endorsements (EN & ES)
+* Public Google Calendar ID
+* External donation processor link or mailing address for checks
+* Optional email newsletter embed code (Mailchimp/Buttondown)
+
+## Media Assets
+
+* 2–3 campaign headshots
+* Campaign logo and color palette
+* Photos for endorsements (with consent)
+* 1‑page platform PDF and any downloadable toolkits
+* Optional video links with captions and Spanish subtitles
+
+## Additional Notes
+
+* All Spanish content must be human reviewed.
+* Compress images for fast load times and provide alt text.
+* Update dates should appear on every page.
+

--- a/docs/PHASE_PLAN.md
+++ b/docs/PHASE_PLAN.md
@@ -1,0 +1,60 @@
+# Phase Plan
+
+This document lists the phased development approach for the campaign website beyond the initial MVP.
+
+## MVP (Ship in 7 Days)
+
+**Objectives**
+* Help voters understand the platform, RSVP, volunteer, donate, and obtain voter information in English or Spanish.
+* Ensure mobile performance and accessibility.
+
+**Required Pages & Components**
+Home, Issues, Events, Volunteer, Voter Info, Donate, Contact, Endorsements, Newsroom, and Spanish mirrors for all.
+
+**Acceptance Criteria**
+* User can RSVP, volunteer, contact, and donate (via external link) in ≤90 seconds on a mid-range Android over 3G.
+* All pages have Spanish counterparts and a persistent toggle.
+* Keyboard-only navigation works; Lighthouse accessibility ≥90 on key pages.
+* Voter Info page contains live official links and key dates.
+* Footer shows “Paid for by [Committee Name] Treasurer [Name].”
+
+## Phase 1 – Stability & Sharing
+
+**Features**
+1. Lite mode to reduce page weight by ≥40% on Home/Issues.
+2. Print-optimized one-pagers for each issue.
+3. Testimonials intake form feeding `_data/endorsements.yml`.
+4. Event cards generated from `_data/events.yml`.
+5. Basic SEO (titles, meta, OpenGraph, sitemap, robots).
+6. Analytics goal tracking.
+
+**Acceptance Criteria**
+* Lite mode meets 40% transfer reduction goal.
+* Each issue prints on a single page at 100% scale.
+* At least five endorsements displayed with alt-texted images.
+
+## Phase 2 – Engagement & Transparency
+
+**Features**
+1. Proposal explainer mini-sites with cost/feasibility FAQs.
+2. Neighborhood listening map (SVG) with no-JS fallback.
+3. Updates blog with tag filters rendered at build time.
+4. Monthly email digest (EN & ES).
+5. Accessibility upgrades: ARIA landmarks, improved skip links, larger mobile fonts.
+
+**Acceptance Criteria**
+* Proposal pages follow Problem → Evidence → Plan → Timeline → Funding → Local Benefits → FAQ.
+* Neighborhood map accessible without JavaScript.
+
+## Phase 3 – Persuasion & Polish
+
+**Features**
+1. Captioned explainer videos (≤120 s) per issue with Spanish subtitles and transcripts.
+2. Endorsement filters (Veterans, Small Business, Educators, Neighborhoods).
+3. Comparison matrix showing differences from opponents with citations.
+4. Lighthouse CI enforcing minimum scores (Perf ≥90, A11y ≥95, Best Practices ≥90, SEO ≥90).
+
+**Acceptance Criteria**
+* Every video includes captions, Spanish subtitles, and an HTML transcript.
+* CI blocks merges if Lighthouse scores fall below targets on Home, Issues, and Events.
+

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,153 @@
+# Project Plan
+
+This document consolidates the vision, requirements, and structure for the Bowling Green campaign website. It covers the ten core site components, technical decisions, accessibility goals, and operational guidelines.
+
+## 1. Site Components
+
+1. **Español ↔ English Toggle** – Maintain mirrored `/es/` pages and a persistent language switch in the header. Translate all forms and ensure content parity. Metric: sessions in Spanish and bounce-rate parity.
+2. **Issues & Solutions Hub** – One page per issue with a 3-sentence summary, plain-language callouts, and printable one-page view. Checklist: problem, plan, local benefits, cost/feasibility, timeline, FAQs.
+3. **Events & RSVP Center** – Embed a public Google Calendar with links to Google Form RSVPs and ICS "Add to Calendar" links. Include accessibility notes, Spanish details, and map links.
+4. **Volunteer Hub** – Google Form sign-up with task checkboxes (door knocking, phone banking, rides, translation, signs). Auto-reply with next steps and toolkit. Include task descriptions, time estimates, training dates, and Spanish version.
+5. **Voter Info Hub** – Step-by-step guidance with links to official state and county portals. Provide key dates, ID basics, accessibility info, FAQs, and Spanish mirrors.
+6. **Donate Page** – Prominent donate button linking to an external processor. Include donor info requirements, "Paid for by" disclaimer, suggested amounts, and check mailing address.
+7. **Endorsements & Neighbor Stories** – Grid or carousel of endorsements with quotes and photos. Collect testimonials through a Google Form and categorize with tags (veterans, small business, etc.).
+8. **Newsroom / Media Kit** – Press-ready assets: bio, headshots, logos, platform one-pager, and contact info. Maintain an updates page for short posts.
+9. **Contact & Office Hours** – Google Form for inquiries, plus phone/SMS and email. Optionally integrate Calendly for meetings. Provide Spanish form and privacy note.
+10. **Accessibility & Senior-Friendly Controls** – Include font-size and high-contrast toggles, print-friendly pages, keyboard navigation, alt text, and labeled forms. Target WCAG 2.2 AA compliance.
+
+## 2. Project Goals
+
+* Inform and persuade Trinidad voters in clear, plain language.
+* Enable quick access to platform summaries, events, volunteer opportunities, donation links, and voter guidance.
+* Provide equal access in English and Spanish.
+
+## 3. Target Audiences
+
+Working parents, older adults, small business owners, low-income renters, veterans, teens/young adults, and new residents. All content must be bilingual and senior-friendly.
+
+## 4. Information Architecture
+
+Top navigation: Home | Issues | Events | Volunteer | Voter Info | Endorsements | Newsroom | Contact | Donate | Español. Spanish content lives under `/es/` with mirrored slugs.
+
+## 5. Tech Stack & Repository Structure
+
+* GitHub Pages with Jekyll
+* Vanilla HTML/CSS/JS, Markdown content, YAML data
+* Analytics via Plausible or GoatCounter
+* Recommended repo tree:
+
+```
+/_config.yml
+/_layouts/
+/_includes/
+/_data/
+/assets/css/
+/assets/js/
+/index.md
+/issues/
+/events/
+/volunteer/
+/voter-info/
+/endorsements/
+/newsroom/
+/contact/
+/donate/
+/es/...
+```
+
+## 6. Site-Wide Requirements
+
+* Mobile-first; page weight ≤200 KB excluding images
+* WCAG 2.2 AA accessibility and keyboard-only navigation
+* Persistent EN↔ES toggle with human-reviewed translations
+* No blocking fonts; responsive images with lazy-load
+* "Last updated" stamp on every page with privacy note
+
+## 7. External Integrations
+
+* Google Forms for RSVP, Volunteer, Contact, Endorsements
+* Google Calendar embed for events with ICS links
+* Mailchimp or Buttondown for optional email list
+* ActBlue/Anedot/Stripe for donations
+* YouTube/Vimeo for video embeds
+* Plausible or GoatCounter analytics
+
+## 8. MVP Scope & Acceptance Criteria
+
+**Pages:** Home, Issues, Events, Volunteer, Voter Info, Donate, Contact, Endorsements, Newsroom, plus Spanish mirrors. Users must be able to RSVP, volunteer, contact, and donate (external) within 90 seconds on 3G.
+
+**Acceptance Criteria:**
+* Spanish parity and persistent toggle across all pages
+* Keyboard navigation for all interactive elements
+* "Voter Info" includes working official links and key election dates
+* Footer shows “Paid for by [Committee Name]” on every page
+
+## 9. Phase Plan
+
+* **Phase 1:** Lite mode, print one-pagers, endorsements intake, event cards, basic SEO, analytics goals.
+* **Phase 2:** Proposal mini-sites, neighborhood listening map, updates blog, monthly email digest, ARIA improvements.
+* **Phase 3:** Video hub with captions, endorsement filters, comparison matrix, Lighthouse CI for performance and accessibility.
+
+## 10. Content Templates
+
+Sample issue page front matter:
+
+```
+---
+layout: page
+title: Affordable Housing
+slug: housing
+lang: en
+permalink: /issues/housing/
+summary: "Rents are up; wages aren’t. Here’s how we add units and protect neighbors."
+printable: true
+tags: [issue]
+---
+```
+
+Each issue page includes a 3-sentence summary, "What this means for Trinidad residents," plan steps, cost & feasibility, FAQs, and an update date.
+
+## 11. Embeds & Snippets
+
+The site will use standard iframe embeds for Google Forms and Calendar, an analytics script tag for Plausible, and JSON‑LD for event metadata.
+
+## 12. Design System
+
+System fonts, high-contrast palette, reusable components (button, card, nav, footer, language toggle, alerts), and print styles via `print.css`.
+
+## 13. Privacy, Security, and Compliance
+
+State what data is collected, avoid unnecessary third-party scripts, and display the required “Paid for by [Committee] Treasurer [Name]” disclaimer. Link to donation rules and contribution limits.
+
+## 14. Analytics & Measurement
+
+Track conversions (donate clicks, RSVP submissions, volunteer sign-ups, voter-info outbound clicks), monitor bounce rate, mobile load time, and Spanish usage.
+
+## 15. Workflow & Governance
+
+Roles include content, translator, web maintainer, and compliance reviewer. Process: Markdown draft → translation → PR review with accessibility check → merge → deploy. Update cadence: weekly events, biweekly issues, monthly digest.
+
+## 16. Risks & Mitigations
+
+* Embeds slowing pages → defer offscreen iframes and provide links
+* Spanish parity gaps → require ES counterparts in same PR
+* Forms blocked by content blockers → include “Open form in new tab” links
+
+## 17. Backlog Summary
+
+**MVP Backlog:** base theme, home, issues, events, volunteer, voter info, donate, contact, endorsements, newsroom, Spanish mirrors.
+
+**Phase 1 Backlog:** lite mode, print one-pagers, endorsements intake, event cards, SEO, analytics goals.
+
+**Phase 2 Backlog:** proposal minisite, neighborhood map, updates blog, stronger accessibility, monthly digest.
+
+**Phase 3 Backlog:** video hub, endorsement filters, comparison matrix, Lighthouse CI gate.
+
+## 18. Domain & Deployment
+
+Initial deployment uses the default GitHub Pages URL. For a custom domain, add a CNAME file, configure DNS, and enable HTTPS. Internal links should be relative, and `baseurl` updated as needed.
+
+## 19. Donation Processor Decision
+
+Select a compliant processor (ActBlue, Anedot, Stripe-hosted, or checks). Update the Donate page link and ensure the “Paid for by…” footer appears on every page.
+

--- a/docs/SPANISH_GLOSSARY.md
+++ b/docs/SPANISH_GLOSSARY.md
@@ -1,0 +1,17 @@
+# Spanish Glossary
+
+Use these terms consistently across the Spanish version of the site.
+
+| English      | Spanish      |
+|--------------|--------------|
+| Home         | Inicio       |
+| Issues       | Propuestas   |
+| Events       | Eventos      |
+| Volunteer    | Voluntariado |
+| Voter Info   | Información para Votantes |
+| Endorsements | Apoyos       |
+| Newsroom     | Sala de Prensa |
+| Contact      | Contacto     |
+| Donate       | Donar        |
+| Español      | Español      |
+

--- a/docs/WORK_ORDERS.md
+++ b/docs/WORK_ORDERS.md
@@ -1,0 +1,40 @@
+# Work Orders
+
+These tasks outline the incremental steps for building the campaign website. Each work order should be completed through pull requests with matching English and Spanish content.
+
+## WO-01: Initialize Repo & Theme (MVP Day 1)
+
+* Create Jekyll repository structure with folders listed in the project plan
+* Add minimal `base.css`, `print.css`, and `contrast.css`
+* Build header, footer, navigation, and EN↔ES toggle
+* Add placeholder pages in English and Spanish
+* Include Plausible/GoatCounter analytics include (commented until a key is available)
+
+## WO-02: Pages & Content Stubs (MVP Day 2)
+
+* Implement layouts, includes, and reusable card components
+* Scaffold Issues pages from template and add print styles
+* Build Events page with Google Calendar iframe and RSVP button placeholder
+
+## WO-03: Forms & Mirrors (MVP Day 3)
+
+* Embed Google Forms for RSVP, Volunteer, and Contact pages
+* Create Spanish versions of all forms and link from `/es/...`
+* Ensure forms open in new tabs if iframes are blocked
+
+## WO-04: Polish & QA (MVP Days 4–5)
+
+* Implement mobile navigation, focus styles, and skip-to-content links
+* Add alt text placeholders and verify keyboard access
+* Run Lighthouse; fix accessibility blockers
+
+## WO-05: Content Load & Launch (MVP Days 6–7)
+
+* Insert real copy, photos, and endorsements
+* Set footer compliance line
+* Publish with GitHub Pages and test flows on mobile
+
+### Post-MVP Work Orders
+
+Phase-specific features are documented in the project plan and include lite mode, event cards, proposal mini-sites, updates blog, video hub, endorsement filters, and performance testing.
+


### PR DESCRIPTION
## Summary
- Replace placeholder README with project overview, tech stack, repo structure, and contribution guidelines
- Add comprehensive project plan detailing site components, requirements, phases, work orders, and asset checklist
- Provide Spanish glossary and copy checklist for bilingual content

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb78340910832796a2522cbe888042