### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: bundle install
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_url }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The `/docs` directory contains detailed planning materials, phase backlogs, and 
 2. Run `bundle install` to install Jekyll and dependencies.
 3. Serve locally with `bundle exec jekyll serve`.
 4. Edit Markdown content or data files, then commit changes via pull request.
+5. Merge to `main` to trigger the GitHub Pages deployment workflow.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Jekyll site and deploy to GitHub Pages
- document automatic deployment trigger in README

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68bb8475550c832c8c9fe97cdb8bda35