### PR TITLE
Fix navigation links to respect site base path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 name: Bowling Green Campaign
-url: "" # set when deploying
-baseurl: ""
+url: "https://thepostman907.github.io"
+baseurl: "/Bowling-Green"
 plugins: []
 markdown: kramdown
 kramdown:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,14 +1,14 @@
 <header>
   <nav>
-    <a href="/">Home</a>
-    <a href="/issues/">Issues</a>
-    <a href="/events/">Events</a>
-    <a href="/volunteer/">Volunteer</a>
-    <a href="/voter-info/">Voter Info</a>
-    <a href="/endorsements/">Endorsements</a>
-    <a href="/newsroom/">Newsroom</a>
-    <a href="/contact/">Contact</a>
-    <a href="/donate/">Donate</a>
+    <a href="{{ '/' | relative_url }}">Home</a>
+    <a href="{{ '/issues/' | relative_url }}">Issues</a>
+    <a href="{{ '/events/' | relative_url }}">Events</a>
+    <a href="{{ '/volunteer/' | relative_url }}">Volunteer</a>
+    <a href="{{ '/voter-info/' | relative_url }}">Voter Info</a>
+    <a href="{{ '/endorsements/' | relative_url }}">Endorsements</a>
+    <a href="{{ '/newsroom/' | relative_url }}">Newsroom</a>
+    <a href="{{ '/contact/' | relative_url }}">Contact</a>
+    <a href="{{ '/donate/' | relative_url }}">Donate</a>
     {% include lang-toggle.html %}
   </nav>
 </header>

--- a/_includes/lang-toggle.html
+++ b/_includes/lang-toggle.html
@@ -1,5 +1,5 @@
 {% if page.lang == "es" %}
-<a href="{{ page.alt }}">English</a>
+<a href="{{ page.alt | relative_url }}">English</a>
 {% else %}
-<a href="{{ page.alt }}">Español</a>
+<a href="{{ page.alt | relative_url }}">Español</a>
 {% endif %}


### PR DESCRIPTION
## Summary
- Configure Jekyll `url` and `baseurl` so `relative_url` generates correct paths on GitHub Pages

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68bcbef89268832cb0b9fa74f52ebfb6