### PR TITLE
Fix landing page by using relative paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bowling Green Campaign</title>
   </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <body>
+      <div id="root"></div>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import Donate from './pages/Donate.jsx';
 
 export default function App() {
   return (
-    <Router>
+    <Router basename="/Bowling-Green/">
       <nav>
         <Link to="/">Home</Link> |{' '}
         <Link to="/issues">Issues</Link> |{' '}

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
 });


### PR DESCRIPTION
## Summary
- Load the bundle entry from a relative path in `index.html` to avoid MIME errors in static deployments
- Configure Vite's `base` as `'./'` so built assets resolve correctly
- Set `BrowserRouter` basename to `/Bowling-Green/` for proper subdirectory routing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bccac22b0c832cbddf3f7e74b34e16