### PR TITLE
Ensure GitHub Pages skips Jekyll for SPA deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy site to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["remove-jekyll-and-convert-to-react-app"]
   workflow_dispatch:
 
 permissions:
@@ -22,8 +22,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
       - run: npm ci
+      - run: npm test
       - run: npm run build
+      - run: cp dist/index.html dist/404.html
+      - run: touch dist/.nojekyll
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# prevent Jekyll processing


### PR DESCRIPTION
## Summary
- cache npm dependencies in Pages workflow
- run tests and build site
- add SPA 404 fallback and disable Jekyll via `.nojekyll`
- deploy workflow on `remove-jekyll-and-convert-to-react-app` branch
- include root `.nojekyll` to prevent any Jekyll builds

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcfbd8c9c8832c9a17a9714802b4c9