### PR TITLE
Fix GitHub Pages workflow to deploy Vite build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./build   # if Vite, use ./dist
+          # Vite outputs the production build to the `dist` directory
+          path: ./dist
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- point GitHub Pages artifact upload to Vite's `dist` directory

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5fcae8f3c832ca98a47cd6a04b56f